### PR TITLE
feat: narrower print width for documentation examples

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,5 +26,13 @@ module.exports = {
                 printWidth: 160,
             },
         },
+        {
+            /* adjust width for examples so they fit in the documentation "view
+             * source" container */
+            files: "**/examples/*.vue",
+            options: {
+                printWidth: 100,
+            },
+        },
     ],
 };


### PR DESCRIPTION
Same PR as @MCFK previously made but directly in the preset instead:

* Applications would not be affected as they dont contain `examples/**/*.vue`
* Other component libraries would gain from having the same change in the documentation examples